### PR TITLE
Fixed problem with calculating stops coordinates inside a tile

### DIFF
--- a/OsmIntegrator/Controllers/TileController.cs
+++ b/OsmIntegrator/Controllers/TileController.cs
@@ -8,6 +8,7 @@ using OsmIntegrator.Database;
 using OsmIntegrator.ApiModels;
 using Microsoft.AspNetCore.Authorization;
 using System.Linq;
+using OsmIntegrator.Database.Models;
 
 namespace OsmIntegrator.Controllers
 {
@@ -63,7 +64,18 @@ namespace OsmIntegrator.Controllers
 
                 var stops = await _dbContext.Stops.Where(x =>
                     x.Lon > result.OverlapMinLon && x.Lon <= result.OverlapMaxLon &&
-                    x.Lat > result.OverlapMinLat && x.Lon <= result.OverlapMaxLat).ToListAsync();
+                    x.Lat > result.OverlapMinLat && x.Lat <= result.OverlapMaxLat).ToListAsync();
+
+                foreach (Stop stop in stops)
+                {
+                    if (stop.Lon > result.MinLon && stop.Lon <= result.MaxLon &&
+                        stop.Lat > result.MinLat && stop.Lat <= result.MaxLat)
+                    {
+                        stop.OutsideSelectedTile = false;
+                        continue;
+                    }
+                    stop.OutsideSelectedTile = true;
+                }
 
                 stops.ForEach(x => x.Tile = null);
 

--- a/OsmIntegrator/Database/Models/Stop.cs
+++ b/OsmIntegrator/Database/Models/Stop.cs
@@ -37,5 +37,7 @@ namespace OsmIntegrator.Database.Models
         public Guid TileId { get; set; }
 
         public Tile Tile { get; set; }
+
+        public bool OutsideSelectedTile { get; set; } = false;
     }
 }

--- a/OsmIntegrator/appsettings.json
+++ b/OsmIntegrator/appsettings.json
@@ -5,7 +5,8 @@
   "JwtExpireMinutes": 10080,
   "FrontendUrl": "http://localhost:3000",
   "ZoomLevel":  12,
-  "OverlapFactor": 0.3,
+  "OverlapFactor": 0.1,
+  "RegisterConfirmationRequired": false,
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {

--- a/postman/OsmIntegrator.postman_collection.json
+++ b/postman/OsmIntegrator.postman_collection.json
@@ -15,7 +15,8 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									""
+									"var data = pm.response.json();",
+									"pm.environment.set(\"token\", data.token);"
 								],
 								"type": "text/javascript"
 							}
@@ -324,7 +325,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"Email\": \"luktar@gmail.com\",\r\n    \"Token\": \"CfDJ8K2ELG/3G8JKu8XfKyA/T0nL34RvYehkfjiigwKpFOPY2JkDOrsi0jP/0ATV2cZb1BRffoYILeY9Y2cJ7ft/zkF1erglPfr4DJGAnqj6oKTVKMvvtClPIOW/O7XC9NgV3TWVxinOnVUQu3sW0U5agasEhRf7blVsiBylxQtm/hjcbexRWE9SKFZEq4KuR9gWlgJsgcZiWb8JBwBB75m7miPujmLeQZ2xzw38JVZDyf1xe/5UbzSEeRLQr4/vrbp+yw==\"\r\n}"
+							"raw": "{\r\n    \"Email\": \"luktar@gmail.com\",\r\n    \"Token\": \"CfDJ8K2ELG/3G8JKu8XfKyA/T0mUCX6eosQwg8LRh7T65hzc1ItOKVpGNGeQHnhgCm+ULQlvBRFd7SSH/PdigKgWdZ+4DYpbduuC3hIVtZ+ti2WCe0KQPyzbiQPjbNw59Sqv8KrQhRkwAsYMn8r3Dxo0URbSh4rDCMKAfVNknz29HLGkdJKDC/JkHGsif5Cu48zfPCKFOswYgkevwDhjODicDg8OC63Wqh4EWv7e4lK7MKS93SLM35H5DjTztu47LpZBaw==\"\r\n}"
 						},
 						"url": {
 							"raw": "{{host}}/api/Account/ConfirmRegistration",
@@ -349,6 +350,21 @@
 				{
 					"name": "GetAll",
 					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "{{{{token}}}}",
+									"type": "string"
+								}
+							]
+						},
 						"method": "GET",
 						"header": [],
 						"url": {
@@ -372,13 +388,25 @@
 			"item": [
 				{
 					"name": "GetAll",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var data = pm.response.json();",
+									"pm.environment.set(\"firstTileId\", data[0].id);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
 					"request": {
 						"auth": {
 							"type": "bearer",
 							"bearer": [
 								{
 									"key": "token",
-									"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJsdWt0YXJAZ21haWwuY29tIiwianRpIjoiNzQzNDY0YjctYjY2MS00NDA4LWI0NGYtMDFlNDNmYzE5ODA1IiwiaHR0cDovL3NjaGVtYXMueG1sc29hcC5vcmcvd3MvMjAwNS8wNS9pZGVudGl0eS9jbGFpbXMvbmFtZWlkZW50aWZpZXIiOiIwOWI0YWQ0NC03ODUzLTQ0NjctODNjNS05MmY4M2YwN2I5MDIiLCJyZWZyZXNoX3Rva2VuIjoia0dRbUtpdmsraHVqeStkeGxoTUk4cnVtTjJ2K1dFa0ozQjdiWU5TaXIvYz0iLCJleHAiOjE2MTM2ODA0NzksImlzcyI6Im9zbWludGVncmF0b3IiLCJhdWQiOiJvc21pbnRlZ3JhdG9yIn0.KT1LxCyUDseG7AEk5tEA52VcEUKkDLbji7v3OFDI_Ow",
+									"value": "{{token}}",
 									"type": "string"
 								},
 								{
@@ -411,7 +439,7 @@
 							"bearer": [
 								{
 									"key": "token",
-									"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJsdWt0YXJAZ21haWwuY29tIiwianRpIjoiZTAzNjc2MjAtZTMwOC00MDQ2LWE2ZTYtNTY0MWQ1MGRkMjYyIiwiaHR0cDovL3NjaGVtYXMueG1sc29hcC5vcmcvd3MvMjAwNS8wNS9pZGVudGl0eS9jbGFpbXMvbmFtZWlkZW50aWZpZXIiOiJmMjdjNTM0Zi1lMzA2LTRjOTMtYWUyYi1mNjY1ZjllOTdkNjYiLCJyZWZyZXNoX3Rva2VuIjoiaXBaMm9Xb2kvaTNLaDQzRXVtOXg3VlQ4VlI2V0RQbVBYMkhpTlFjbElFTT0iLCJleHAiOjE2MTM2MDExODgsImlzcyI6Im9zbWludGVncmF0b3IiLCJhdWQiOiJvc21pbnRlZ3JhdG9yIn0.FZICa33ZBlNmsNjmk9U6VWurzRyi4BAixR_xCAzdpZk",
+									"value": "{{token}}",
 									"type": "string"
 								},
 								{
@@ -424,13 +452,48 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{host}}/api/Tile",
+							"raw": "{{host}}/api/Tile/cd67a467-6c15-4036-b793-b8f8accceefd",
 							"host": [
 								"{{host}}"
 							],
 							"path": [
 								"api",
-								"Tile"
+								"Tile",
+								"cd67a467-6c15-4036-b793-b8f8accceefd"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GetById FirstTile",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "{{{{token}}}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/api/Tile/{{firstTileId}}",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"Tile",
+								"{{firstTileId}}"
 							]
 						}
 					},

--- a/postman/osmintegrator_local_iis.postman_environment.json
+++ b/postman/osmintegrator_local_iis.postman_environment.json
@@ -6,9 +6,19 @@
 			"key": "host",
 			"value": "https:\\\\localhost:44388",
 			"enabled": true
+		},
+		{
+			"key": "token",
+			"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJsdWt0YXJAZ21haWwuY29tIiwianRpIjoiMDI0MzAwM2ItYzMzNi00YmZmLTgxNmUtMzc2MjllNTMyYWZhIiwiaHR0cDovL3NjaGVtYXMueG1sc29hcC5vcmcvd3MvMjAwNS8wNS9pZGVudGl0eS9jbGFpbXMvbmFtZWlkZW50aWZpZXIiOiI3NWQyOWVjNS1jMjUwLTQ0NjEtODE5Zi05YTc0YzA2OGU5ZmUiLCJyZWZyZXNoX3Rva2VuIjoiZmdmVWNYNXhyMU9LR0dJQmgvSUJuQWYyaldqVE9pOFlFeFAwQzZ0Q09Sbz0iLCJleHAiOjE2MTEwMDYyODcsImlzcyI6Im9zbWludGVncmF0b3IiLCJhdWQiOiJvc21pbnRlZ3JhdG9yIn0.LU46ityzuqm_CN9x5m5WGXeAElWJRzZnuC2zt4QWKiw",
+			"enabled": true
+		},
+		{
+			"key": "firstTileId",
+			"value": "Kf2pl4DYNqRTgN8Rb+5SpZSp9en+bWpybQi3ekcoJwc=",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2020-12-20T16:27:26.551Z",
-	"_postman_exported_using": "Postman/7.25.0"
+	"_postman_exported_at": "2021-02-14T10:51:19.346Z",
+	"_postman_exported_using": "Postman/8.0.4"
 }

--- a/postman/osmintegrator_local_kestrel.postman_environment.json
+++ b/postman/osmintegrator_local_kestrel.postman_environment.json
@@ -6,9 +6,19 @@
 			"key": "host",
 			"value": "http:\\\\localhost:9998",
 			"enabled": true
+		},
+		{
+			"key": "token",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "firstTileId",
+			"value": "",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2020-12-20T16:27:23.207Z",
-	"_postman_exported_using": "Postman/7.25.0"
+	"_postman_exported_at": "2021-02-14T10:51:34.912Z",
+	"_postman_exported_using": "Postman/8.0.4"
 }

--- a/postman/osmintegrator_remote.postman_environment.json
+++ b/postman/osmintegrator_remote.postman_environment.json
@@ -6,9 +6,19 @@
 			"key": "host",
 			"value": "https://vps-6fb8d81b.vps.ovh.net:9999",
 			"enabled": true
+		},
+		{
+			"key": "token",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "firstTileId",
+			"value": "",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2020-12-20T16:27:16.038Z",
-	"_postman_exported_using": "Postman/7.25.0"
+	"_postman_exported_at": "2021-02-14T10:51:46.828Z",
+	"_postman_exported_using": "Postman/8.0.4"
 }


### PR DESCRIPTION
Poprawiłem błąd. Okazało się, że podczas sprawdzania przynależności przystanków do wybranego kafelka pomyliłem Lat z Lon - czeski błąd.
Dodatkowo wprowadziłem następujące zmiany:
Każdy przystanek Stop ma teraz dodatkowe property OutsideSelectedTile, które mówi o tym, czy przystanek znajduje się w zaznaczonym kafelku false, czy pola nim true.
W pierwotnej wersji zakładaliśmy, że będziemy wczytywać przystanki ze wszystkich kafelków na około tego zaznaczonego. Przystanków jest za dużo przy obecnym zoomie więc wprowadziłem margines, czyli wczytywane są tylko przystanki w odległości 30% szerokości/wysokości kafelka zaznaczonego. Niestety 30% to też za dużo i zmieniłem to na 10%. Więc teraz endpoint zwracający przystanki dla wybranego tile'a zwróci tylko te wew. zaznaczonego kafelki i znajdujące się wokół kafelka na obramowaniu o szer. 10% bieżącego kafelka. (Jak to jest niejasne to dajcie znać)
W postmanie nie trzeba rejestracji potwierdzać mailem. To było irytujące podczas testów gdy często musiałem kasować bazę danych i tworzyć użytkownika wraz z potwierdzeniem mailowym żeby dostać się do metod chronionych. Oczywiście zmienną konfiguracyjną można to z powrotem włączyć.
W postmanie nie trzeba już kopiować token po zalogowaniu. Jest on zapisywany w zmiennej {{token}} i po prostu można wołać metody chronione bez kopiowania tokena.