### PR TITLE
disable recurrent serialization

### DIFF
--- a/OsmIntegrator/Startup.cs
+++ b/OsmIntegrator/Startup.cs
@@ -54,10 +54,9 @@ namespace osmintegrator
             // ===== Add our DbContext ========
             services.AddDbContext<ApplicationDbContext>();
             services.AddControllers()
-                .AddJsonOptions(options =>
+                .AddNewtonsoftJson(options =>
                 {
-                    options.JsonSerializerOptions.WriteIndented = true;
-                    options.JsonSerializerOptions.IgnoreNullValues = true;
+                    options.SerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore;
                 });
 
             // ===== Allow-Origin ========
@@ -126,7 +125,7 @@ namespace osmintegrator
                 typeof(ApplicationUserProfile),
                 typeof(StopLinkProfile),
                 typeof(NoteProfile));
-                
+
             services.AddSingleton<IEmailService, EmailService>();
             services.AddSingleton<IModelValidator, ModelValidator>();
             services.AddSingleton<ITokenHelper, TokenHelper>();

--- a/OsmIntegrator/osmintegrator.csproj
+++ b/OsmIntegrator/osmintegrator.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.4" NoWarn="NU1605" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.4" NoWarn="NU1605" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.4">


### PR DESCRIPTION
modele wskazuja na siebie nawzajem co powodowało rekurencję w serailzacji. system.text.json w ogóle nie wspiera tego ficzeru, dlatego Newtonsoft.json 