### PR TITLE
Fixed problems with swagger and db

### DIFF
--- a/OsmIntegrator/Controllers/ErrorController.cs
+++ b/OsmIntegrator/Controllers/ErrorController.cs
@@ -21,7 +21,7 @@ namespace OsmIntegrator.Controllers
             _logger = logger;
         }
 
-        [Route("/error-local-development")]
+        [HttpGet("/error-local-development")]
         public IActionResult ErrorLocalDevelopment(
             [FromServices] IWebHostEnvironment webHostEnvironment)
         {
@@ -54,7 +54,7 @@ namespace OsmIntegrator.Controllers
         }
 
 
-        [Route("/error")]
+        [HttpGet("/error")]
         public IActionResult Error()
         {
             var context = HttpContext.Features.Get<IExceptionHandlerFeature>();

--- a/OsmIntegrator/Startup.cs
+++ b/OsmIntegrator/Startup.cs
@@ -139,6 +139,7 @@ namespace osmintegrator
 
             services.AddAuthorization();
             services.AddControllers();
+            services.AddSwaggerGenNewtonsoftSupport();
             services.AddSwaggerGen(c =>
             {
                 c.SwaggerDoc("v1", new OpenApiInfo { Title = "osmintegrator", Version = "v1" });

--- a/OsmIntegrator/osmintegrator.csproj
+++ b/OsmIntegrator/osmintegrator.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.9.3" />
     <PackageReference Include="NLog" Version="4.7.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,10 +42,9 @@ services:
         image: postgres
         restart: always
         ports:
-            - 5434:5432
+            - 5433:5432
         env_file:
-            - .env.production # that does not exist in the repo, need to be adjusted for tahrget server
-
+            - .env.production # that does not exist in the repo, need to be adjusted for target server
         volumes:
             - pgdata:/var/lib/postgresql/data
 


### PR DESCRIPTION
Swagger się nie generował ponieważ:
1. Serializer został zmieniony na newtonsoft i trzeba było wgrać brakującą bibliotekę
2. Zamiast `Route` powinien być użyty np. `HttpGet` jak w tym wątku: https://stackoverflow.com/a/53632914/1816687

Port dla kontenera bazodanowego powinien być ustawiony na 5433.