### PR TITLE
Feature 157

### DIFF
--- a/OsmIntegrator/Controllers/ErrorController.cs
+++ b/OsmIntegrator/Controllers/ErrorController.cs
@@ -21,7 +21,7 @@ namespace OsmIntegrator.Controllers
             _logger = logger;
         }
 
-        [HttpGet("/error-local-development")]
+        [Route("/error-local-development")]
         public IActionResult ErrorLocalDevelopment(
             [FromServices] IWebHostEnvironment webHostEnvironment)
         {
@@ -54,7 +54,7 @@ namespace OsmIntegrator.Controllers
         }
 
 
-        [HttpGet("/error")]
+        [Route("/error")]
         public IActionResult Error()
         {
             var context = HttpContext.Features.Get<IExceptionHandlerFeature>();

--- a/OsmIntegrator/Controllers/ErrorController.cs
+++ b/OsmIntegrator/Controllers/ErrorController.cs
@@ -22,6 +22,7 @@ namespace OsmIntegrator.Controllers
         }
 
         [Route("/error-local-development")]
+        [ApiExplorerSettings(IgnoreApi = true)]
         public IActionResult ErrorLocalDevelopment(
             [FromServices] IWebHostEnvironment webHostEnvironment)
         {
@@ -55,6 +56,7 @@ namespace OsmIntegrator.Controllers
 
 
         [Route("/error")]
+        [ApiExplorerSettings(IgnoreApi = true)]
         public IActionResult Error()
         {
             var context = HttpContext.Features.Get<IExceptionHandlerFeature>();


### PR DESCRIPTION
https://rozwiazaniadlaniewidomych.atlassian.net/browse/PT-157

W `ErrorControler` potrzebujemy atrybutu `Route` zamiast `HttpGet`. To nie jest endpoint widoczny na zewnątrz, nie chcemy pokazywać tego w `swaggerze`. To jest wewnętrzne rozwiązanie do łapania wtyjątków z kontrolerów