### PR TITLE
Feature PT-161

### DIFF
--- a/OsmIntegrator/Controllers/ConnectionsController.cs
+++ b/OsmIntegrator/Controllers/ConnectionsController.cs
@@ -84,7 +84,7 @@ namespace OsmIntegrator.Controllers
 
             // Check if GTFS stop has already been connected to another stop.
             DbStop gtfsStop = await _dbContext.Stops
-                .Include(x => x.Connections)
+                .Include(x => x.GtfsConnections)
                 .FirstOrDefaultAsync(x => x.Id == connectionAction.GtfsStopId);
 
             if (gtfsStop == null)
@@ -92,7 +92,7 @@ namespace OsmIntegrator.Controllers
                 throw new BadHttpRequestException(_localizer["Please ensure correct stops were chosen"]);
             }
 
-            DbConnections gtfsConnection = gtfsStop.Connections
+            DbConnections gtfsConnection = gtfsStop.GtfsConnections
                 .OrderByDescending(link => link.CreatedAt)
                 .FirstOrDefault();
 
@@ -103,7 +103,7 @@ namespace OsmIntegrator.Controllers
 
             // Check if OSM stop has already been connected to another stop.
             DbStop osmStop = await _dbContext.Stops
-                .Include(x => x.Connections)
+                .Include(x => x.OsmConnections)
                 .FirstOrDefaultAsync(x => x.Id == connectionAction.OsmStopId);
 
             if (osmStop == null)
@@ -111,7 +111,7 @@ namespace OsmIntegrator.Controllers
                 throw new BadHttpRequestException(_localizer["Please ensure correct stops were chosen"]);
             }
 
-            DbConnections osmConnection = osmStop.Connections
+            DbConnections osmConnection = osmStop.OsmConnections
                 .OrderByDescending(link => link.CreatedAt)
                 .FirstOrDefault();
 
@@ -125,6 +125,8 @@ namespace OsmIntegrator.Controllers
             DbConnections newConnection = new DbConnections()
             {
                 OsmStop = osmStop,
+                OsmStopId = osmStop.Id,
+                GtfsStopId = gtfsStop.Id,
                 GtfsStop = gtfsStop,
                 User = currentUser,
                 Imported = imported,

--- a/OsmIntegrator/Database/ApplicationDbContext.cs
+++ b/OsmIntegrator/Database/ApplicationDbContext.cs
@@ -28,21 +28,18 @@ namespace OsmIntegrator.Database
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            // Self many-to-many implemented thanks to this solution: 
-            // https://stackoverflow.com/questions/49214748/many-to-many-self-referencing-relationship
-            // Cascade delete was disabled: https://docs.microsoft.com/pl-pl/ef/core/saving/cascade-delete
             modelBuilder.Entity<DbConnections>()
                 .HasKey(t => new { t.Id });
 
             modelBuilder.Entity<DbConnections>()
                 .HasOne(c => c.OsmStop)
-                .WithMany(o => o.Connections)
+                .WithMany(o => o.OsmConnections)
                 .HasForeignKey(c => c.OsmStopId)
                 .OnDelete(DeleteBehavior.NoAction);
 
             modelBuilder.Entity<DbConnections>()
                 .HasOne(c => c.GtfsStop)
-                .WithMany()
+                .WithMany(o => o.GtfsConnections)
                 .HasForeignKey(c => c.GtfsStopId)
                 .OnDelete(DeleteBehavior.NoAction);
 
@@ -61,7 +58,7 @@ namespace OsmIntegrator.Database
                 .HasMany(t => t.Users)
                 .WithMany(u => u.Tiles)
                 .UsingEntity(j => j.ToTable("ApplicationUserDbTile"));
-                
+
             base.OnModelCreating(modelBuilder);
         }
 

--- a/OsmIntegrator/Database/Models/DbStop.cs
+++ b/OsmIntegrator/Database/Models/DbStop.cs
@@ -40,12 +40,14 @@ namespace OsmIntegrator.Database.Models
 
         public bool OutsideSelectedTile { get; set; } = false;
 
-        public List<DbConnections> Connections { get; set; }
+        public List<DbConnections> GtfsConnections { get; set; }
+
+        public List<DbConnections> OsmConnections { get; set; }
 
         public long Ref { get; set; }
 
         public int Version { get; set; }
 
         public string Changeset { get; set; }
-    }    
+    }
 }

--- a/OsmIntegrator/Migrations/20210804142334_MultiConnectionListInStop.Designer.cs
+++ b/OsmIntegrator/Migrations/20210804142334_MultiConnectionListInStop.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using OsmIntegrator.Database;
@@ -11,9 +12,10 @@ using OsmIntegrator.Database.Models;
 namespace osmintegrator.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210804142334_MultiConnectionListInStop")]
+    partial class MultiConnectionListInStop
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OsmIntegrator/Migrations/20210804142334_MultiConnectionListInStop.cs
+++ b/OsmIntegrator/Migrations/20210804142334_MultiConnectionListInStop.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace osmintegrator.Migrations
+{
+    public partial class MultiConnectionListInStop : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
https://rozwiazaniadlaniewidomych.atlassian.net/browse/PT-161

Wygląda na to, że poprzednie rozwiązanie dotyczące dwóch kluczy obcych ze DbStop w DbConnections było nie wystarczające. Nie rzucało wyjątkiem ale nie pozwalało na relację wstęczną. WYdaje mi się że nie ma innej możliwości jak rozbicie tego na dwie kolekcje. Próbowałem zrobić jedną wspłna i napisać jakąś logikę w geterach i seterach, ale to sie wysypuje w momencie tworzenia nowych encji. Albo mi brakuje wiedzy albo sie nie da tak. 